### PR TITLE
Fix flag name in lint command for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: bash
 
 script:
   - bin/fetch-configlet
-  - bin/configlet lint --track TRACK_ID .
+  - bin/configlet lint --track-id pharo .


### PR DESCRIPTION
I missed this when bootstrapping.