### PR TITLE
Store metadata in package "Properties" class var.

### DIFF
--- a/dev/src/ExercismTools/AbstractNautilusUI.extension.st
+++ b/dev/src/ExercismTools/AbstractNautilusUI.extension.st
@@ -3,13 +3,13 @@ Extension { #name : #AbstractNautilusUI }
 { #category : #'*ExercismTools' }
 AbstractNautilusUI class >> packagesExercismMenu: aBuilder [
 	<nautilusGlobalPackageMenu>
-	| package target packageTree |
+	| packageOrTag target packageTree |
 	
 	target := aBuilder model.
 	(packageTree := target selectedPackage) ifNil: [ ^ target ].
 	(packageTree packageName = 'Exercism') ifFalse: [ ^ target ].
 	
-	package := packageTree item.
+	packageOrTag := packageTree item.
 	
 	(aBuilder item: #'Exercism')
 		label: 'Exercism';
@@ -19,18 +19,22 @@ AbstractNautilusUI class >> packagesExercismMenu: aBuilder [
 		
 	(aBuilder item: #'Fetch Exercise...')
 		parent: #'Exercism';
-		action: [ ExercismManager default fetchFromExercismTo: package ];
+		action: [ ExercismManager default fetchFromExercismTo: packageOrTag ];
 		order: 100;
 		help: 'Fetch next Exercism example from exercism.io'.
 	(aBuilder item: #'Submit Solution')
 		parent: #'Exercism';
-		action: [ ExercismManager default submitToExercism: package ];
+		action: [ ExercismManager default submitToExercism: packageOrTag ];
 		order: 101;
 		help: 'Submit a completed Exercism example to exercism.io'.
 	(aBuilder item: #'View Track Progress')
 		parent: #'Exercism';
-		action: [ ExercismManager default viewOnExercism: package ];
+		action: [ ExercismManager default viewOnExercism: packageOrTag ];
 		order: 102;
 		help: 'View the Pharo track on www.exercism.io'.
-	
+	(aBuilder item: #'View metadata')
+		parent: #'Exercism';
+		action: [ ((RPackageOrganizer default packageNamed: 'Exercism') ensureProperties at: packageOrTag)  inspect];
+		order: 105;
+		help: 'View Exercism solution metadata (maybe only during dev/debug).'.
 ]

--- a/dev/src/ExercismTools/ExercismDownload.class.st
+++ b/dev/src/ExercismTools/ExercismDownload.class.st
@@ -85,30 +85,28 @@ ExercismDownload >> getSolutionData [
 
 { #category : #internal }
 ExercismDownload >> installExercise [
-	| rpo root packagesToAnnounce |
+	| rpo exercismPackage packagesToAnnounce |
 	rpo := RPackageOrganizer default.
-	root := rpo packageNamed: 'Exercism' ifAbsent: [ rpo createPackageNamed: 'Exercism' ].
+	exercismPackage := rpo packageNamed: 'Exercism' ifAbsent: [ rpo createPackageNamed: 'Exercism' ].
 	packagesToAnnounce := OrderedCollection new.
 
 	filesContentMap keysAndValuesDo: 
-		[:filename :contents | (filename endsWith: '.st') ifTrue: 
-			[|parser|
-				parser := TonelParser on: contents readStream.
+	[	:filename :contents | (filename endsWith: '.st') ifTrue: 
+		[	|parser|
+			parser := TonelParser on: contents readStream.
          		parser document do: 
-					[:def | 
-						def isClassDefinition ifTrue: "Maybe not needed, see todo-discussion"
-						[	rpo packageNamed: def category ifAbsent: [	packagesToAnnounce add: def ] 
-						].
-						def load
-					].
+			[	:def | 
+				def load.
+				def isClassDefinition ifTrue: 
+				[	|tag|	
+					"Store solution metadata."
+					tag := exercismPackage classTagNamed:  (exercismPackage toTagName:  def category).
+					exercismPackage ensureProperties at: tag put: solution.
+				].
 			].
 		].
-	
-	"TODO-DISCUSSION: Do package class-tags (which we have, i.e. not packages) need to be announced?
-	 i.e. Was the system announcement previously in fetchFromExercismTo: 
-	 only required for updating the System Browser to show the loaded tag?
-	 And will the following suffice? "
-	SystemAnnouncer uniqueInstance announce: (RPackageRegistered to: root).
+	].
+	SystemAnnouncer uniqueInstance announce: (RPackageRegistered to: exercismPackage).
 ]
 
 { #category : #accessing }

--- a/dev/src/ExercismTools/ExercismSubmit.class.st
+++ b/dev/src/ExercismTools/ExercismSubmit.class.st
@@ -27,3 +27,17 @@ Class {
 	#superclass : #ExercismCommand,
 	#category : #ExercismTools
 }
+
+{ #category : #'as yet unclassified' }
+ExercismSubmit class >> solutionDataForExercise: exerciseString [ 
+	| rpo exercismPackage packagesToAnnounce |
+	rpo := RPackageOrganizer default.
+	exercismPackage := RPackageOrganizer default 
+		packageNamed: 'Exercism' 
+		ifAbsent: [ self error: 'No exercises downloaded.' ].
+	exercismPackage ensureProperties 
+		detect: [ :solutionData | ((solutionData at: 'exercise') at: 'id') = exerciseString ] 
+		ifFound: [ :solutionData | ^ solutionData ] 
+		ifNone: [ self error: 'Exercise ''' , exerciseString , ''' not downloaded.'].
+	
+]

--- a/dev/src/ExercismTools/ExercismSubmitTest.class.st
+++ b/dev/src/ExercismTools/ExercismSubmitTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #ExercismSubmitTest,
+	#superclass : #TestCase,
+	#category : #'ExercismTools-Tests'
+}
+
+{ #category : #running }
+ExercismSubmitTest >> setUp [
+	ExercismCommand verifyToken 
+]
+
+{ #category : #tests }
+ExercismSubmitTest >> testsolutionDataForExercise [
+	|solutionData|
+	ExercismDownload exercise: 'hello-world'.
+	solutionData := ExercismSubmit solutionDataForExercise: 'hello-world'.
+	self assert: ((solutionData at: 'exercise') at: 'id') equals: 'hello-world'.
+]


### PR DESCRIPTION
We need somewhere to store the exercise metadata to be used by Submit command.  Some options are: 
- as a class comment
- as a special method
- a Manifest-like class
- in the package's "Properties" class variable

I'd first like to try the last one since it has the least visual distraction for students.
To test this PR...
1. Create an empty "Exercism" package
2. Right-click on "Exercism" package > Exercism > Fetch Exercise = hello-world
3. Right click on "HelloWorld" tag> Exercism > View metadata