### PR TITLE
Allow generated ZnMimeParts to be accepted by Exercism

### DIFF
--- a/dev/src/ExercismTools/ZnMimePart.extension.st
+++ b/dev/src/ExercismTools/ZnMimePart.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #ZnMimePart }
+
+{ #category : #'*ExercismTools' }
+ZnMimePart class >> fieldName: fieldName fileName: fileName entity: entity [
+	"Pathnames are often silenty encoded using UTF-8,
+	this is a no-op for ASCII, but will fail on Latin-1 and others"
+
+	| encodedFileName |
+	encodedFileName := fileName utf8Encoded asString.
+	^ self new
+		setContentDisposition: 'form-data; name="', fieldName, '";filename="', encodedFileName, '"';
+		entity: entity;
+		yourself
+]


### PR DESCRIPTION
This one is preparation for finally fixing #96. @bencoman this manual patch is as you showed in the same issue. I just manually added the missing white space and adopted the method by changing its protocol to `*ExercismTools`. I'm guessing when our code is loaded into a fresh image, this change will get merged and patch the method for us? 
