### PR TITLE
Issue 96: Submit exercises via HTTP patch method

### DIFF
--- a/dev/src/ExercismTools/ExercismCommand.class.st
+++ b/dev/src/ExercismTools/ExercismCommand.class.st
@@ -71,7 +71,7 @@ ExercismCommand class >> configureToken [
 ExercismCommand class >> configureToken: your_CLI_token [
     "Get your_CLI_token at https://exercism.io/my/settings"
     ApiToken := your_CLI_token.
-    ApiPath := '/v1/solutions/latest'.
+    ApiPath := '/v1/solutions'.
 ]
 
 { #category : #testing }
@@ -85,6 +85,13 @@ ExercismCommand class >> newHttpClient [
           https;
           host: 'api.exercism.io';
           headerAt: 'Authorization' put: 'Bearer ' , self token
+]
+
+{ #category : #command }
+ExercismCommand class >> reset [
+	ApiPath := nil.
+	ApiToken := nil.
+	
 ]
 
 { #category : #'as yet unclassified' }
@@ -106,4 +113,9 @@ ExercismCommand >> initialize [
 { #category : #internal }
 ExercismCommand >> path [
 	^ApiPath copy
+]
+
+{ #category : #'test support' }
+ExercismCommand >> responseCode [
+	^ httpclient response code
 ]

--- a/dev/src/ExercismTools/ExercismDownload.class.st
+++ b/dev/src/ExercismTools/ExercismDownload.class.st
@@ -38,7 +38,7 @@ ExercismDownload class >> exercise: exerciseId [
 	^(self new track: 'pharo' exercise: exerciseId) execute
 ]
 
-{ #category : #'instance-creation' }
+{ #category : #command }
 ExercismDownload class >> track: trackId exercise: exerciseId [
 	^(self new track: trackId exercise: exerciseId) execute
 ]
@@ -71,7 +71,7 @@ ExercismDownload >> filesContentMap [
 ExercismDownload >> getSolutionData [
 	| responseString response |
 	httpclient 
-		path: self path;
+		path: self path, '/latest';
 		queryAt: 'track_id' put: track;
 		queryAt: 'exercise_id' put: exercise.
 		
@@ -81,6 +81,7 @@ ExercismDownload >> getSolutionData [
 	response at: 'error' ifPresent: [ :error | self error: (error at: 'message') ].
 	
 	solution := response at: 'solution'.
+	ExercismManager solutionData at: exercise put: solution.
 ]
 
 { #category : #internal }
@@ -94,16 +95,7 @@ ExercismDownload >> installExercise [
 	[	:filename :contents | (filename endsWith: '.st') ifTrue: 
 		[	|parser|
 			parser := TonelParser on: contents readStream.
-         		parser document do: 
-			[	:def | 
-				def load.
-				def isClassDefinition ifTrue: 
-				[	|tag|	
-					"Store solution metadata."
-					tag := exercismPackage classTagNamed:  (exercismPackage toTagName:  def category).
-					exercismPackage ensureProperties at: tag put: solution.
-				].
-			].
+         	parser document do: [:def | def load].
 		].
 	].
 	SystemAnnouncer uniqueInstance announce: (RPackageRegistered to: exercismPackage).
@@ -117,5 +109,5 @@ ExercismDownload >> solution [
 { #category : #accessing }
 ExercismDownload >> track: aStringTrack exercise: aStringExercise [
 	track := aStringTrack.
-	exercise := aStringExercise.
+	exercise := aStringExercise asKebabCase.
 ]

--- a/dev/src/ExercismTools/ExercismManager.class.st
+++ b/dev/src/ExercismTools/ExercismManager.class.st
@@ -72,9 +72,7 @@ ExercismManager >> submitToExercism: packageOrTag [
 				collect: [ :cls | 
 					self pathStringFor: (submissionDirectoryRef / (writer fileNameFor: cls asClassDefinition)) ]).
 				
-	cmd := 'exercism submit ' , filesToSubmit.
-	result := PipeableOSProcess waitForCommand: cmd.
-	result succeeded ifFalse: [ self error: 'Unable to submit solution, CLI reported ', result outputAndError printString ].
+	ExercismSubmit exercise: exerciseName.
 	
 	UIManager default inform: 'Successfully submitted solution!'
 ]

--- a/dev/src/ExercismTools/ExercismManager.class.st
+++ b/dev/src/ExercismTools/ExercismManager.class.st
@@ -1,9 +1,12 @@
 "
-I am  responsible for managing the interaction with the lower level Execercism command line tool.
+I am  responsible for managing the interaction with the lower level Exercism command line tool.
 "
 Class {
 	#name : #ExercismManager,
 	#superclass : #Object,
+	#classVars : [
+		'SolutionData'
+	],
 	#category : #ExercismTools
 }
 
@@ -12,6 +15,11 @@ ExercismManager class >> default [
 	"answer a defulat manager"
 	
 	^self new
+]
+
+{ #category : #exercism }
+ExercismManager class >> solutionData [
+	^ SolutionData ifNil: [ SolutionData := Dictionary new ]
 ]
 
 { #category : #exercism }

--- a/dev/src/ExercismTools/ExercismSubmit.class.st
+++ b/dev/src/ExercismTools/ExercismSubmit.class.st
@@ -16,71 +16,93 @@ Class {
 	#name : #ExercismSubmit,
 	#superclass : #ExercismCommand,
 	#instVars : [
-		'exercise',
-		'exerciseMap'
+		'classes',
+		'exerciseMap',
+		'packageTag'
 	],
 	#category : #ExercismTools
 }
 
-{ #category : #accessing }
+{ #category : #command }
+ExercismSubmit class >> class: aClass [ 
+	^ self classes: { aClass }
+]
+
+{ #category : #command }
+ExercismSubmit class >> classes: classes [
+	^ (self new classes: classes) execute
+]
+
+{ #category : #command }
 ExercismSubmit class >> exercise: exerciseId [
-	^ (self new exercise: exerciseId) execute
-]
-
-{ #category : #accessing }
-ExercismSubmit class >> solutionDataForClass: aClass [ 
-	| exercismPackage classTag |
-	exercismPackage := RPackageOrganizer default 
-		packageNamed: 'Exercism' 
-		ifAbsent: [ self error: 'No exercises downloaded.' ].
-	classTag := exercismPackage classTagForClass: aClass.  
-	^ exercismPackage ensureProperties at: classTag.
-	
-]
-
-{ #category : #accessing }
-ExercismSubmit class >> solutionDataForExercise: exerciseString [ 
-	| exercismPackage |
-	exercismPackage := RPackageOrganizer default 
-		packageNamed: 'Exercism' 
-		ifAbsent: [ self error: 'No exercises downloaded.' ].
-	exercismPackage ensureProperties 
-		detect: [ :solutionData | ((solutionData at: 'exercise') at: 'id') = exerciseString ] 
-		ifFound: [ :solutionData | ^ solutionData ] 
-		ifNone: [ self error: 'Exercise ''' , exerciseString , ''' not downloaded.'].
-	
+	"Submit whole package-tag specified by exerciseId."
+	"By default, don't submit TestCases with solution (if needed use #classes: direct)"
+	|rootPackage packageTag solutionClasses|
+	rootPackage := RPackageOrganizer default packageNamed: 'Exercism'.
+	packageTag := rootPackage classTagNamed: exerciseId kebabAsCamelCase.
+	solutionClasses := packageTag classes select: [:class | (class new isKindOf: TestCase) not].
+	(solutionClasses size > 0) ifFalse: [  self error: 'No classes to submit' ].
+	^ self classes: solutionClasses
 ]
 
 { #category : #internal }
 ExercismSubmit >> buildRequest [
-	| solutionEntity solutionPart multiPartFormDataEntity solutionId |
-	"Assumption: There is only one entity to make which is from the class with the same name as the exercise."
-	solutionEntity := ZnByteArrayEntity bytes: (exerciseMap at: exercise capitalized asSymbol).
-	solutionPart := ZnMimePart exercismFieldName: 'files[]' fileName: exercise entity: solutionEntity.
-	multiPartFormDataEntity := ZnMultiPartFormDataEntity new addPart: solutionPart.
-	solutionId := (self class solutionDataForExercise: exercise capitalized) at: 'id'.
+	| solutionClasses multiPartFormDataEntity solutionId exercise |
+	multiPartFormDataEntity := ZnMultiPartFormDataEntity new.
+	classes do: [ :solutionClass | |solutionPart solutionEntity|
+		solutionEntity := ZnByteArrayEntity bytes: (exerciseMap at: solutionClass name asSymbol).
+		solutionPart := ZnMimePart exercismFieldName: 'files[]' fileName: solutionClass name, '.st' entity: solutionEntity.
+		multiPartFormDataEntity addPart: solutionPart.
+	].
+	
+	solutionId := (ExercismManager solutionData at: packageTag name asKebabCase) at: 'id'.
 	
 	httpclient 
 		url: ApiPath , '/' , solutionId;
 		entity: multiPartFormDataEntity
 ]
 
+{ #category : #accessing }
+ExercismSubmit >> classes: arrayOfClasses [
+	"Simplification - only submit classes for one exercise at a time"
+	| firstPackage rootPkg|
+	rootPkg := RPackageOrganizer default packageNamed: 'Exercism'.
+	firstPackage := nil.
+	arrayOfClasses do: [ :c | |package|
+		c isClass ifFalse: [ self error: c printString, ' is not a class.' ].
+		package := rootPkg classTagForClass: c.
+		firstPackage
+			ifNil: [ firstPackage := package ]
+			ifNotNil: [ (firstPackage = package) 
+				ifFalse: [ self error: 'Classes must belong to same package' ] 
+				]
+		].
+	classes := arrayOfClasses.
+
+]
+
 { #category : #execution }
 ExercismSubmit >> execute [
+	|status|
+	self writeExercise.
 	self buildRequest.
 	httpclient patch.
+	status := httpclient response statusLine.
+	status code = 201 ifTrue: [ self inform: 'Exercism submit solution - SUCCESS.'. ^self ].
+	status code = 400 ifTrue: [ self inform: 'Exercism submit solution - NO CHANGES.'. ^self ].
+	self error: 'Exercism submit solution - UNKNOWN ERROR (', status code printString, ' ', status reason, ')'.
 	
 ]
 
-{ #category : #accessing }
-ExercismSubmit >> exercise: aStringExercise [
-	exercise := aStringExercise.
-	self writeExercise
+{ #category : #execution }
+ExercismSubmit >> isOkay [
+	|status|
+	status := httpclient response statusLine.
+	^ (status code = 201) | (status code = 400)
 ]
 
 { #category : #internal }
 ExercismSubmit >> writeExercise [
-	| packageTag |
-	packageTag := (RPackageOrganizer default packageNamed: 'Exercism') classTagForClass: (Smalltalk classNamed: exercise capitalized asSymbol).
+	packageTag := (RPackageOrganizer default packageNamed: 'Exercism') classTagForClass: classes anyOne.
 	exerciseMap := TonelWriter new mappedSnapshot: packageTag snapshot
 ]

--- a/dev/src/ExercismTools/ExercismSubmit.class.st
+++ b/dev/src/ExercismTools/ExercismSubmit.class.st
@@ -1,33 +1,23 @@
 "
-STUB CLASS TODO
+# Description
+I am a command for submitting an exercise back to Exercism.io.
 
-Please comment me using the following template inspired by Class Responsibility Collaborator (CRC) design:
+# Instance Variables
+* `exercise` - a string of the exercise to be submitted.
+* `exerciseMap` - a dictionary containing the source code of each exercise class in Tonel format. The keys are symbols of the class names.
 
-For the Class part:  State a one line summary. For example, ""I represent a paragraph of text"".
+# Usage
+The command can be created an used instantly with `ExercismSubmit exercise: exerciseId`, where `exercisedId` is the string of an exercise name in
+kebab case e.g. `'hello-world'`.
 
-For the Responsibility part: Three sentences about my main responsibilities - what I do, what I know.
-
-For the Collaborators Part: State my main collaborators and one line about how I interact with them. 
-
-Public API and Key Messages
-
-- message one   
-- message two 
-- (for bonus points) how to create instances.
-
-   One simple example is simply gorgeous.
- 
-Internal Representation and Key Implementation Points.
-
-
-    Implementation Points
+The command makes use of the `httpClient` instance variable from the `ExercismCommand` superclass.
 "
 Class {
 	#name : #ExercismSubmit,
 	#superclass : #ExercismCommand,
 	#instVars : [
 		'exercise',
-		'exerciseContents'
+		'exerciseMap'
 	],
 	#category : #ExercismTools
 }
@@ -64,10 +54,11 @@ ExercismSubmit class >> solutionDataForExercise: exerciseString [
 { #category : #internal }
 ExercismSubmit >> buildRequest [
 	| solutionEntity solutionPart multiPartFormDataEntity solutionId |
-	solutionEntity := ZnByteArrayEntity bytes: exerciseContents.
-	solutionPart := ZnMimePart exercismFieldName: 'files[]' fileName: 'Acronym.class.st' entity: solutionEntity.
+	"Assumption: There is only one entity to make which is from the class with the same name as the exercise."
+	solutionEntity := ZnByteArrayEntity bytes: (exerciseMap at: exercise capitalized asSymbol).
+	solutionPart := ZnMimePart exercismFieldName: 'files[]' fileName: exercise entity: solutionEntity.
 	multiPartFormDataEntity := ZnMultiPartFormDataEntity new addPart: solutionPart.
-	solutionId := (self class solutionDataForExercise: exercise) at: 'id'.
+	solutionId := (self class solutionDataForExercise: exercise capitalized) at: 'id'.
 	
 	httpclient 
 		url: ApiPath , '/' , solutionId;
@@ -83,9 +74,13 @@ ExercismSubmit >> execute [
 
 { #category : #accessing }
 ExercismSubmit >> exercise: aStringExercise [
-	| path |
 	exercise := aStringExercise.
+	self writeExercise
+]
 
-	path := (Path from: (aStringExercise asKebabCase)) / '.pharo' / aStringExercise capitalized , 'class.st'.
-	exerciseContents := (FileStream readOnlyFileNamed: path) contents.
+{ #category : #internal }
+ExercismSubmit >> writeExercise [
+	| packageTag |
+	packageTag := (RPackageOrganizer default packageNamed: 'Exercism') classTagForClass: (Smalltalk classNamed: exercise capitalized asSymbol).
+	exerciseMap := TonelWriter new mappedSnapshot: packageTag snapshot
 ]

--- a/dev/src/ExercismTools/ExercismSubmit.class.st
+++ b/dev/src/ExercismTools/ExercismSubmit.class.st
@@ -25,8 +25,17 @@ Internal Representation and Key Implementation Points.
 Class {
 	#name : #ExercismSubmit,
 	#superclass : #ExercismCommand,
+	#instVars : [
+		'exercise',
+		'exerciseContents'
+	],
 	#category : #ExercismTools
 }
+
+{ #category : #accessing }
+ExercismSubmit class >> exercise: exerciseId [
+	^ (self new exercise: exerciseId) execute
+]
 
 { #category : #accessing }
 ExercismSubmit class >> solutionDataForClass: aClass [ 
@@ -50,4 +59,33 @@ ExercismSubmit class >> solutionDataForExercise: exerciseString [
 		ifFound: [ :solutionData | ^ solutionData ] 
 		ifNone: [ self error: 'Exercise ''' , exerciseString , ''' not downloaded.'].
 	
+]
+
+{ #category : #internal }
+ExercismSubmit >> buildRequest [
+	| solutionEntity solutionPart multiPartFormDataEntity solutionId |
+	solutionEntity := ZnByteArrayEntity bytes: exerciseContents.
+	solutionPart := ZnMimePart exercismFieldName: 'files[]' fileName: 'Acronym.class.st' entity: solutionEntity.
+	multiPartFormDataEntity := ZnMultiPartFormDataEntity new addPart: solutionPart.
+	solutionId := (self class solutionDataForExercise: exercise) at: 'id'.
+	
+	httpclient 
+		url: ApiPath , '/' , solutionId;
+		entity: multiPartFormDataEntity
+]
+
+{ #category : #execution }
+ExercismSubmit >> execute [
+	self buildRequest.
+	httpclient patch.
+	
+]
+
+{ #category : #accessing }
+ExercismSubmit >> exercise: aStringExercise [
+	| path |
+	exercise := aStringExercise.
+
+	path := (Path from: (aStringExercise asKebabCase)) / '.pharo' / aStringExercise capitalized , 'class.st'.
+	exerciseContents := (FileStream readOnlyFileNamed: path) contents.
 ]

--- a/dev/src/ExercismTools/ExercismSubmitTest.class.st
+++ b/dev/src/ExercismTools/ExercismSubmitTest.class.st
@@ -10,17 +10,21 @@ ExercismSubmitTest >> setUp [
 ]
 
 { #category : #tests }
-ExercismSubmitTest >> testSolutionDataForClass [
-	|solutionData|
-	ExercismDownload exercise: 'hello-world'.
-	solutionData := ExercismSubmit solutionDataForClass: HelloWorld.
-	self assert: ((solutionData at: 'exercise') at: 'id') equals: 'hello-world'.
+ExercismSubmitTest >> testSubmitHelloWorldClass [
+	|exercise downloadCmd|
+	exercise := 'hello-world'.
+	downloadCmd := ExercismDownload new track: 'pharo' exercise: exercise.
+	downloadCmd getSolutionData.
+	self assert: (ExercismSubmit class: HelloWorld) isOkay.
+	
 ]
 
 { #category : #tests }
-ExercismSubmitTest >> testsolutionDataForExercise [
-	|solutionData|
-	ExercismDownload exercise: 'hello-world'.
-	solutionData := ExercismSubmit solutionDataForExercise: 'hello-world'.
-	self assert: ((solutionData at: 'exercise') at: 'id') equals: 'hello-world'.
+ExercismSubmitTest >> testSubmitHelloWorldPackage [
+	|exercise downloadCmd|
+	exercise := 'hello-world'.
+	downloadCmd := ExercismDownload new track: 'pharo' exercise: exercise.
+	downloadCmd getSolutionData.
+	self assert: (ExercismSubmit exercise: exercise) isOkay.
+	
 ]

--- a/dev/src/ExercismTools/String.extension.st
+++ b/dev/src/ExercismTools/String.extension.st
@@ -13,3 +13,11 @@ String >> asKebabCase [
 						ifTrue: [ kebabStream nextPut: $- ].
 					kebabStream nextPut: char asLowercase ] ]
 ]
+
+{ #category : #'*ExercismTools' }
+String >> kebabAsCamelCase [
+	"Answer a String that converts the CamelCase input to camel-case kebab output 
+	used by exercism"
+
+	^ (self copyReplaceAll: {$-} with: {Character space}) asCamelCase.
+]

--- a/dev/src/ExercismTools/TonelWriter.extension.st
+++ b/dev/src/ExercismTools/TonelWriter.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #TonelWriter }
+
+{ #category : #'*ExercismTools' }
+TonelWriter >> mappedSnapshot: aSnapshot [
+	"extracted from #writeSnapshot:"
+	|tonelMap|
+	snapshot := aSnapshot.
+	tonelMap := Dictionary new.
+	(snapshot definitions select: #isClassDefinition)
+		do: [ :classdef |  |tonelStream|
+			tonelStream := WriteStream on: String new.
+	 		self writeClass: classdef on: tonelStream.
+	  		tonelMap at: classdef className put: tonelStream contents ].
+	^tonelMap
+
+]
+
+{ #category : #'*ExercismTools' }
+TonelWriter >> writeClass: aClassDefinition on: aStream [
+	self writeClassDefinition: aClassDefinition on: aStream.
+	self writeClassSideMethodDefinitions: aClassDefinition on: aStream.
+	self writeInstanceSideMethodDefinitions: aClassDefinition on: aStream 
+]


### PR DESCRIPTION
I broadly understand what this thing needs to do now. I won't be able to spend anytime on this tomorrow so I'm placing this pull request here to make sure I'm on the right track. Hopefully I'll be able to get back to it this weekend.

This is definitely a work in progress. A few more helper methods will probably be made, plus getting rid of some hard coded values. 

I used the Acronym exercise as an example, which means I could not test submitting because I have not downloaded the exercise metadata, which I can't do because I haven't unlocked the exercise ¯\_(ツ)_/¯ .

I've left a few comments in the source code with my thoughts and a few problems I haven't yet solved. Let me know what you think.

I'm also irritates me that I don't have any tests of the public interface. For lack of a good mocking framework it will take a bit of work to mock Exercisms API, and the OS file system.

