### PR TITLE
128-Adds simple parsing for exercise name

### DIFF
--- a/dev/src/ExercismTools/ClyExercismCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismCommand.class.st
@@ -12,8 +12,11 @@ Class {
 
 { #category : #testing }
 ClyExercismCommand class >> isExercismTagIn: aToolContext [
-	^ aToolContext lastSelectedClassGroup classes anyOne 
-		package name = ExercismManager exercismPackageName 
+
+	aToolContext lastSelectedClassGroup classes do: [:any |
+		^any package name = ExercismManager exercismPackageName]. 
+	
+	^false
 ]
 
 { #category : #accessing }

--- a/dev/src/ExercismTools/ExercismManager.class.st
+++ b/dev/src/ExercismTools/ExercismManager.class.st
@@ -43,15 +43,28 @@ ExercismManager class >> welcome [
 
 { #category : #exercism }
 ExercismManager >> fetchFromExercismTo: package [
-	| exercise |
+	| exerciseName |
 	
-	(exercise := UIManager default
+	exerciseName := (UIManager default
 		request: 'Enter a valid exercism exercise (e.g. hello-world):')
-		ifNil: [ ^ self ].
+			ifNil: [ ^ self ]
+			ifNotNil: [ :value | self parseExerciseName: value ].
 		
-	UIManager default inform: 'Loading: ' , exercise.
-	(ExercismDownload exercise: exercise) 
-		ifTrue: [ UIManager default inform: 'Success, Happy Coding']
+	UIManager default inform: 'Loading: ' , exerciseName.
+	(ExercismDownload exercise: exerciseName)
+		ifTrue: [ UIManager default inform: 'Success, Happy Coding' ]
+]
+
+{ #category : #helpers }
+ExercismManager >> parseExerciseName: aString [ 
+	| parsedTokens exerciseOffset |
+	parsedTokens := aString findTokens: '= '.
+	parsedTokens size = 1 ifTrue: [ ^parsedTokens first ].
+	
+	(exerciseOffset := parsedTokens indexOf: '--exercise') > 1 ifTrue: [ 
+		^parsedTokens at: exerciseOffset + 1 ].
+	
+	^nil
 ]
 
 { #category : #exercism }

--- a/dev/src/ExercismTools/ExercismManagerTest.class.st
+++ b/dev/src/ExercismTools/ExercismManagerTest.class.st
@@ -1,0 +1,17 @@
+"
+An ExercismManagerTest is a test class for testing the behavior of ExercismManager
+"
+Class {
+	#name : #ExercismManagerTest,
+	#superclass : #TestCase,
+	#category : #'ExercismTools-Tests'
+}
+
+{ #category : #tests }
+ExercismManagerTest >> testParseExerciseProposal [
+
+	self assert: (ExercismManager default parseExerciseName: 'hello-world') equals: 'hello-world'.
+	self assert: (ExercismManager default parseExerciseName: 'exercism download --exercise=two-fer --track=pharo') equals: 'two-fer'.
+	self assert: (ExercismManager default parseExerciseName: 'exercism download --randome') equals: nil.
+	self assert: (ExercismManager default parseExerciseName: '') equals: nil.
+]


### PR DESCRIPTION
Allow users to simply paste the provided exercism command line instructions into the fetch dialog (as well as the kebab case exercise name). This makes it simpler to follow the instructions on the website.

(cherry picked from commit 86e9467) - to provide a clean diff